### PR TITLE
fix(get_transfer): scp now requires a flag -T

### DIFF
--- a/sps.cxx
+++ b/sps.cxx
@@ -85,7 +85,7 @@ int get_transfert(std::string host, std::string exec_cmd)
 	vector_string_t param = tokenize_string(exec_cmd, '`');
 	if (param.size() == 4)
 	{
-		std::string cmd = "scp -p " + SSH_OPTS + " root@" + host + ":\"'" + param[1] + "'\" '" + param[3] + "'";
+		std::string cmd = "scp -T -p " + SSH_OPTS + " root@" + host + ":\"'" + param[1] + "'\" '" + param[3] + "'";
 		return exit_status(system(cmd.c_str()));
 	}
 	else


### PR DESCRIPTION
See also this SO thread: [scp fails with “protocol error: filename does not match request”](https://stackoverflow.com/a/54599326/9164010).